### PR TITLE
Add `IsTrashCan` flag to `trashcontainers_01`

### DIFF
--- a/Contents/mods/BuildingMenu/media/lua/shared/BM_TilesPatches.lua
+++ b/Contents/mods/BuildingMenu/media/lua/shared/BM_TilesPatches.lua
@@ -167,6 +167,7 @@ Events.OnLoadedTileDefinitions.Add(function(manager)
         { IsoFlagType.container },
         { "container",          "bin",  false },
         { "ContainerCapacity",  "50",   false },
+        { "IsTrashCan",  "",   false },
     });
 
     BM_Utils.setOrUnsetSpriteProperties(manager, {


### PR DESCRIPTION
Vanilla has a "Remove all" feature for all trash bin, only available for MP.